### PR TITLE
Update README.md To Include Install Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 - Expansive library of themes
 
 ## Setup
+
+### Install Dependencies
+Run `npm install` to install the required dependencies
+
 ### Run
 Run `npm start` to start a webserver and the Bare server. You may deploy Metallic by using an external bare server and a static file host. Metallic must be built before attempting to start.
 


### PR DESCRIPTION
After downloading this project, the setup instruction usually don't work. The user has to run `npm install` to install the required dependencies before running the project. I updated the documentation to reflect this.